### PR TITLE
Have cuts as proper parsers, instead of keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The following example shows this, and also how to add a hard cut in the `chain` 
 ```clj
 (def example
   (maybe (chain (literal "(")
-                :hard-cut
+                hard-cut
                 (regex #"\d+")
                 (literal ")"))))
 
@@ -226,7 +226,7 @@ Consider the expansion of the previous example:
   (choice (chain
             ;; --- same as before, but now with soft-cut
             (maybe (chain (literal "(")
-                          :soft-cut
+                          soft-cut
                           (regex #"\d+")
                           (literal ")")))
             ;; ---
@@ -241,7 +241,7 @@ Consider the expansion of the previous example:
      {:key :expected-literal, :at 0, :detail {:literal "bar"}}}
 ```
 
-The `:hard-cut` has been replaced with a `:soft-cut`.
+The `hard-cut` has been replaced with a `soft-cut`.
 As shown, this still shows a localized error for the missing `")"`, yet it also allows backtracking to try the `"bar"` choice.
 
 Since backtracking before the soft cut is still allowed outside of the chain's scope, the cache is not affected.
@@ -249,7 +249,7 @@ However, soft and hard cuts can be combined in a grammar.
 We could for instance extend the grammar a bit more:
 
 ```clj
-(repeat+ (chain example :hard-cut))
+(repeat+ (chain example hard-cut))
 ```
 
 This effectively says that after each finished `example`, we won't backtrack, that part is done.

--- a/src/crustimoney/core.clj
+++ b/src/crustimoney/core.clj
@@ -91,7 +91,7 @@
                (cond
                  ;; Backtrack further on a soft-cut error result, when the parser is
                  ;; not tagged as recovering
-                 (and (some-> result meta :soft-cut) (not (-> parser meta :recovering)))
+                 (and (set? result) (some-> result meta :soft-cut) (not (-> parser meta :recovering)))
                  result
                  ;; Handle backtracking a result
                  result

--- a/src/crustimoney/core.clj
+++ b/src/crustimoney/core.clj
@@ -32,6 +32,12 @@
             true
             (recur (dec i))))))))
 
+(defn- soft-cut-catcher
+  [_text _index result _state]
+  (if (r/success? result)
+    result
+    (with-meta result {:soft-cut true})))
+
 ;;; Parsing virtual machine
 
 (defn parse
@@ -118,10 +124,20 @@
              ;; Handle a success result
              (r/success? result)
              (let [processed (post-success result)]
-               ;; Check if it was a hard-cut success
-               (if (-> result meta :hard-cut)
-                 (do (caches/cut cache (r/success->end result))
-                     (recur (pop stack) processed state' (r/success->end result)))
+               (cond
+                 ;; Handle a hard-cut
+                 (-> result meta :hard-cut)
+                 (do (caches/cut cache index)
+                     (recur (pop stack) processed state' index))
+
+                 ;; Handle a soft-cut
+                 (-> result meta :soft-cut)
+                 (let [popped  (pop stack)
+                       chain   (peek popped)
+                       catcher (r/->push soft-cut-catcher (r/push->index chain) (r/push->state chain))]
+                   (recur (conj (pop popped) catcher chain) processed state' cut-at))
+
+                 :else
                  (do (caches/store cache parser index processed)
                      (recur (pop stack) processed state' cut-at))))
 

--- a/src/crustimoney/data_grammar.clj
+++ b/src/crustimoney/data_grammar.clj
@@ -1,7 +1,8 @@
 (ns crustimoney.data-grammar
   "Create a parser based on a data grammar. The data is translated into
   combinators."
-  (:require [crustimoney.vector-grammar :as vector-grammar]))
+  (:require [crustimoney.combinators :as c]
+            [crustimoney.vector-grammar :as vector-grammar]))
 
 ;;; Utility functions
 
@@ -80,8 +81,8 @@
     (let [ref-name (str data)]
       (case ref-name
         "$"  [:eof]
-        ">>" :hard-cut
-        ">"  :soft-cut
+        ">>" c/hard-cut
+        ">"  c/soft-cut
         [:ref (keyword ref-name)]))))
 
 (extend-type String

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -21,19 +21,19 @@
     :non-terminal= (c/regex "[a-zA-Z_-]+")
 
     :literal (c/chain (c/literal "'")
-                      :soft-cut
+                      c/soft-cut
                       (c/with-name :literal
                         (c/regex #"(\\'|[^'])*"))
                       (c/literal "'"))
 
     :character-class= (c/chain (c/literal "[")
-                               :soft-cut
+                               c/soft-cut
                                (c/regex #"(\\]|[^]])*")
                                (c/literal "]")
                                (c/regex #"[?*+]?"))
 
     :regex= (c/chain (c/literal "#")
-                     :soft-cut
+                     c/soft-cut
                      (c/ref :literal))
 
     :end-of-file= (c/literal "$")
@@ -46,12 +46,12 @@
     :cut= (c/choice (c/literal ">>") (c/literal ">"))
 
     :group-name (c/chain (c/literal ":")
-                         :soft-cut
+                         c/soft-cut
                          (c/with-name :group-name
                            (c/regex "[a-zA-Z_-]+")))
 
     :group= (c/chain (c/literal "(")
-                     :soft-cut
+                     c/soft-cut
                      (c/maybe (c/ref :group-name))
                      (c/ref :space)
                      (c/ref :choice)
@@ -74,7 +74,7 @@
     :lookahead (c/choice (c/with-name :lookahead
                            (c/chain (c/with-name :operand
                                       (c/regex "[&!]"))
-                                    :soft-cut
+                                    c/soft-cut
                                     (c/ref :quantified)))
                          (c/ref :quantified))
 
@@ -98,7 +98,7 @@
                                (c/maybe (c/literal "="))))
                     (c/ref :space)
                     (c/literal "<-")
-                    :hard-cut
+                    c/hard-cut
                     (c/ref :space)
                     (c/ref :choice))
 
@@ -192,7 +192,7 @@
 
 (defmethod vector-tree-for :cut
   [text node]
-  ({">>" :hard-cut, ">" :soft-cut} (r/success->text text node)))
+  ({">>" c/hard-cut, ">" c/soft-cut} (r/success->text text node)))
 
 ;;; Public namespace API
 

--- a/test/crustimoney/combinators_test.clj
+++ b/test/crustimoney/combinators_test.clj
@@ -35,10 +35,10 @@
       (is (= (r/->success 0 0) (parse p "anything")))))
 
   (testing "chain with soft-cut"
-    (is (thrown? AssertionError (c/chain :soft-cut)))
+    (is (thrown? AssertionError (c/chain c/soft-cut)))
 
     (let [p (c/choice (c/chain (c/maybe (c/chain (c/literal "{")
-                                                 :soft-cut
+                                                 c/soft-cut
                                                  (c/literal "foo")
                                                  (c/literal "}")))
                                (c/literal "bar"))
@@ -51,10 +51,10 @@
       (is (= (r/->success 0 8) (core/parse p "{foo}bar")))))
 
   (testing "chain with hard-cut"
-    (is (thrown? AssertionError (c/chain :hard-cut)))
+    (is (thrown? AssertionError (c/chain c/hard-cut)))
 
     (let [p (c/choice (c/chain (c/maybe (c/chain (c/literal "{")
-                                                 :hard-cut
+                                                 c/hard-cut
                                                  (c/literal "foo")
                                                  (c/literal "}")))
                                (c/literal "bar"))
@@ -66,12 +66,9 @@
       (is (= (r/->success 0 8) (core/parse p "{foo}bar")))))
 
   (testing "chain with cuts results in correct children"
-    (let [p (c/chain (c/literal "foo") :soft-cut (c/literal "bar"))]
-      (is (= (r/->success 0 6 [(r/->success 0 3) (r/->success 3 6)])
-             (parse p "foobar")))))
-
-  (testing "chain with unknown keyword"
-    (is (thrown? AssertionError (c/chain (c/literal "foo") :unknown)))))
+    (let [p (c/chain (c/literal "foo") c/soft-cut (c/literal "bar"))]
+      (is (= (r/->success 0 6 [(r/->success 0 3) (r/->success 3 3) (r/->success 3 6)])
+             (parse p "foobar"))))))
 
 (deftest choice-test
   (testing "choice with two parsers"


### PR DESCRIPTION
The upside is a cleaner implementation and less chance of a typo.

It would also clear the way, for if we would decide that passing keyword as parsers would be a good idea. It might, it might not.

The downside is that the parsers can now be used anywhere, instead of nicely restricted to chains, at the right places.