### PR TITLE
Allow grammar macro to be nested

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ This grammar can be used as follows:
 => [nil {:start 0, :end 6}]
 ```
 
+The `grammar` macro can take multiple maps, which are merged.
+The macro can also be nested, where it is the most outer one that does the actual resolving.
+
 ## Auto-named rules
 
 The example above shows that all success nodes are filtered out, except the root node, as they are nameless.
@@ -299,12 +302,12 @@ However, it is perfectly valid to define a single parser, such as:
 'alice and ' !'eve' [a-z]+
 ```
 
-A second argument can be passed to `create-parser`, which is a map of other parsers that can be used by the grammar.
-For example:
+Keep in mind that `grammar` takes multiple maps, which is utilised in the following example:
 
 ```clj
-(create-parser "root <- 'Hello ' email"
-               {:email (regex "...")})
+(grammar
+ (create-parser "root <- 'Hello ' email")
+ {:email (regex #"...")})
 ```
 
 The names of the rules can have an `=` sign appended, for the auto-named feature discussed earlier.
@@ -351,7 +354,7 @@ It is very similar to the string-based grammar.
 The function `data-grammar/create-parser` is used to create a parser out of such a definition.
 
 The data-based definition shares many properties with the string-based one.
-It works the same way in supporting both recursive and non-recursive parsers, it also has auto-naming (the `=` postfix), and it can take an extra map of predefined parsers as well.
+It works the same way in supporting both recursive and non-recursive parsers, it also has auto-naming (the `=` postfix), and can be used as part fo a bigger grammar.
 
 It does have an extra feature: direct combinator calls, using vectors.
 The first keyword in the vector determines the combinator.

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ It is very similar to the string-based grammar.
 The function `data-grammar/create-parser` is used to create a parser out of such a definition.
 
 The data-based definition shares many properties with the string-based one.
-It works the same way in supporting both recursive and non-recursive parsers, it also has auto-naming (the `=` postfix), and can be used as part fo a bigger grammar.
+It works the same way in supporting both recursive and non-recursive parsers, it also has auto-naming (the `=` postfix), and can be used as part of a bigger grammar.
 
 It does have an extra feature: direct combinator calls, using vectors.
 The first keyword in the vector determines the combinator.

--- a/src/crustimoney/combinators/experimental.clj
+++ b/src/crustimoney/combinators/experimental.clj
@@ -3,21 +3,17 @@
   or dismissed.
 
   These combinators are not available in the string- or data-driven
-  grammar (yet). To use them with those, you can use the
-  `other-parsers` parameter of their respective `create-parser`
-  functions, like:
+  grammar (yet). To use them with those, combine them in a larger
+  grammar like so:
 
       (require '[crustimoney.combinators.experimental :as e])
 
-      (create-parser
-        \"root= <- stream
-         expr= <- '{' [0-9]+ '}'\"
-        {:stream [::e/stream handle-expr
-                  [::e/recover [:ref :expr] [:regex \".*?}\"]]})
-
-  Note that the other-parsers here is written in vector-grammar
-  format. This is a little power-user trick, and allows you to declare
-  `ref`s that do not have to resolve immediatly on their creation."
+      (grammar
+       (create-parser
+         \"root= <- stream
+          expr= <- '{' [0-9]+ '}'\")
+       {:stream (e/stream handle-expr
+                 (e/recover (ref :expr) (regex \".*?}\")))})"
   (:refer-clojure :exclude [range])
   (:require [crustimoney.results :as r]))
 

--- a/src/crustimoney/data_grammar.clj
+++ b/src/crustimoney/data_grammar.clj
@@ -143,20 +143,18 @@
   captured using the rule's name (without the postfix). Please read up
   on this at `crustimoney.combinators/grammar`.
 
-  Optionally an existing map of parsers can be supplied, which can
-  refered to by the data grammar. For example:
+  Keep in mind that `grammar` takes multiple maps, all of which can be
+  referred to by the string grammar. For example:
 
-      (create-parser '{root (\"Hello \" email)}
-                     {:email (regex \"...\")})
+      (grammar
+       (create-parser '{root (\"Hello \" email)})
+       {:email (regex #\"...\")})
 
   If you want to use an EDN grammar file or string, you can use
   `#crusti/regex` tagged literal for regular expressions. To read
   this, use the following:
 
       (clojure.edn/read-string {:readers *data-readers*} ...)"
-  ([data]
-   (create-parser data nil))
-  ([data other-parsers]
-   (-> (vector-tree data)
-       (vector-grammar/merge-other other-parsers)
-       (vector-grammar/create-parser))))
+  [data]
+  (-> (vector-tree data)
+      (vector-grammar/create-parser)))

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -243,14 +243,12 @@
   captured using the rule's name (without the postfix). Please read up
   on this at `crustimoney.combinators/grammar`.
 
-  A map of existing parsers can be supplied, which can be used by the
-  string grammar. For example:
+  Keep in mind that `grammar` takes multiple maps, all of which can be
+  referred to by the string grammar. For example:
 
-      (create-parser \"root <- 'Hello ' email\"
-                     {:email (regex \"...\")})"
-  ([text]
-   (create-parser text nil))
-  ([text other-parsers]
-   (-> (vector-tree text)
-       (vector-grammar/merge-other other-parsers)
-       (vector-grammar/create-parser))))
+      (grammar
+       (create-parser \"root <- 'Hello ' email\")
+       {:email (regex #\"...\")})"
+  [text]
+  (-> (vector-tree text)
+      (vector-grammar/create-parser)))

--- a/src/crustimoney/vector_grammar.clj
+++ b/src/crustimoney/vector_grammar.clj
@@ -2,22 +2,6 @@
   "A basic vector-driven parser generator."
   (:require [crustimoney.combinators :as c]))
 
-;;; Utility functions
-
-(defn- map-kv [kf vf m]
-  (reduce-kv (fn [a k v] (assoc a (kf k) (vf v))) {} m))
-
-(defn ^:no-doc merge-other [tree other-parsers]
-  (cond (and (map? tree) other-parsers)
-        (merge other-parsers tree)
-
-        other-parsers
-        (throw (IllegalArgumentException.
-                "Supplying other parsers needs named rules in input grammar"))
-
-        :else
-        tree))
-
 ;;; Parser creation
 
 (defn- key-to-combinator [key]
@@ -46,7 +30,7 @@
   formats, such as the string-based and data-based grammars."
   [tree]
   (cond (map? tree)
-        (c/grammar (map-kv identity create-parser tree))
+        (c/grammar (update-vals tree create-parser))
 
         (vector? tree)
         (if-let [combinator (key-to-combinator (first tree))]

--- a/test/crustimoney/data_grammar_test.clj
+++ b/test/crustimoney/data_grammar_test.clj
@@ -1,5 +1,6 @@
 (ns crustimoney.data-grammar-test
   (:require [clojure.test :refer [deftest testing is]]
+            [crustimoney.combinators :as c]
             [crustimoney.core :as core]
             [crustimoney.results :as r]
             [crustimoney.data-grammar :refer [create-parser vector-tree]]))
@@ -105,17 +106,9 @@
              (core/parse p "foobaz")))))
 
   (testing "extra rules"
-    (let [p (create-parser '{root foo} {:foo (create-parser "foo")})]
-      (is (r/success? (core/parse (:root p) "foo"))))
-
-    (let [p (create-parser '{root foo} {:foo [:literal "foo"]})]
-      (is (r/success? (core/parse (:root p) "foo"))))
-
-    (let [p (create-parser '{foo "foo"} {:foo (create-parser "bar")})]
-      (is (r/success? (core/parse (:foo p) "foo"))))
-
-    (is (thrown-with-msg? Exception #"Supplying other parsers needs named rules in input grammar"
-                          (create-parser 'foo {:foo (create-parser "'foo'")}))))
+    (let [p (c/grammar (create-parser '{root foo})
+                       {:foo (create-parser "foo")})]
+      (is (r/success? (core/parse (:root p) "foo")))))
 
   (testing "unknown type"
     (is (thrown-with-msg? Exception #"Unknown data type"

--- a/test/crustimoney/string_grammar_test.clj
+++ b/test/crustimoney/string_grammar_test.clj
@@ -1,5 +1,6 @@
 (ns crustimoney.string-grammar-test
   (:require [clojure.test :refer [deftest testing is]]
+            [crustimoney.combinators :as c]
             [crustimoney.core :as core]
             [crustimoney.results :as r]
             [crustimoney.string-grammar :refer [create-parser vector-tree]]))
@@ -119,17 +120,9 @@
              (core/parse p "foobaz")))))
 
   (testing "extra rules"
-    (let [p (create-parser "root <- foo" {:foo (create-parser "'foo'")})]
-      (is (r/success? (core/parse (:root p) "foo"))))
-
-    (let [p (create-parser "root <- foo" {:foo [:literal "foo"]})]
-      (is (r/success? (core/parse (:root p) "foo"))))
-
-    (let [p (create-parser "foo <- 'foo'" {:foo (create-parser "'bar'")})]
-      (is (r/success? (core/parse (:foo p) "foo"))))
-
-    (is (thrown-with-msg? Exception #"Supplying other parsers needs named rules in input grammar"
-                          (create-parser "foo" {:foo (create-parser "'foo'")}))))
+    (let [p (c/grammar (create-parser "root <- foo")
+                       {:foo (create-parser "'foo'")})]
+      (is (r/success? (core/parse (:root p) "foo")))))
 
   (testing "report grammar errors"
     (let [thrown (try (create-parser "(foo") (catch Exception e e))]


### PR DESCRIPTION
And have the most outer one do the resolving. This removes the need for an `other-parsers` parameter for the grammar dialects. It also allows multiple grammar to refer to each other, without the need for the vector-syntax workaround.