### PR TITLE
Add `results/transform` to have more batteries included

### DIFF
--- a/.clj-kondo/.gitignore
+++ b/.clj-kondo/.gitignore
@@ -1,0 +1,2 @@
+.lock
+/.cache

--- a/.clj-kondo/inline-configs/crustimoney.results.clj/config.edn
+++ b/.clj-kondo/inline-configs/crustimoney.results.clj/config.edn
@@ -1,1 +1,1 @@
-{:lint-as {crustimoney.results/coerce clojure.core/fn, crustimoney.results/unite clojure.core/fn}}
+{:lint-as {crustimoney.results/coerce clojure.core/fn, crustimoney.results/collect clojure.core/fn}}

--- a/.clj-kondo/inline-configs/crustimoney.results.clj/config.edn
+++ b/.clj-kondo/inline-configs/crustimoney.results.clj/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {crustimoney.results/coerce clojure.core/fn, crustimoney.results/unite clojure.core/fn}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.clj-kondo/
 /.lein-repl-history
 /.lsp/
 **/*.~undo-tree~

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ For example:
 
 To work with these successes and errors, the functions in the `results` namespace can be used.
 These allow you to get the text of a success node for example, or add `:line` and `:column` keys to the errors.
+It also contains tools to walk and transform the tree (see [built-in transformer](#built-in-transformer)).
 
 ## Recursive grammars
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Otherwise it applies the transformation functions, which are functions that rece
 
 The `coerce` macro creates such a transformer, by applying a function to the node's matched text.
 Instead of a function, `coerce` can take a binding vector and a body.
-So the `:number` transformation above could also be written as `(coerce [s] (parse-long s))`
+So the `:number` transformation above could also be written as `(coerce [s] (parse-long s))`. It could also be written without the macro as `(fn [text node] (parse-long (success->text node text)))`.
 
 The `unite` macro creates a transformation function, by applying a function to the node's children, as seen with the `nil` (root node) transformer above.
 Instead of a function, `unite` can take a binding vector and a body, as seen with the `:operation` transformer.

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ While not necessary (as the results tree is made of plain vectors), it does incr
 Writing your own parse tree processor is easy, as again, it's just data.
 That said, the `results` namespace has a `transform` function.
 This performs a postwalk, transforming the nodes based on their name, using a function that receives the node and the full text.
-Two accompanying helper macros are available, called `coerce` and `unite`.
+Two accompanying helper macros are available, called `coerce` and `collect`.
 Here is an example:
 
 ```clj
@@ -455,8 +455,8 @@ Here is an example:
     (transform text
       {:number    (coerce parse-long)
        :operand   (coerce {"+" + "-" - "*" * "/" /})
-       :operation (unite [[v1 op v2]] (op v1 v2))
-       nil        (unite first)}))
+       :operation (collect [[v1 op v2]] (op v1 v2))
+       nil        (collect first)}))
 ```
 
 If the parse result is not a success, the `transform` returns it as is.
@@ -467,8 +467,8 @@ Instead of a function, `coerce` can also take a binding vector and a body.
 So the `:number` transformation above could be written as `(coerce [s] (parse-long s))`.
 It could also be written without the macro as `(fn [node text] (parse-long (success->text node text)))`.
 
-The `unite` macro creates a transformation function, by applying a function to the node's children, as seen with the `nil` (root node) transformer above.
-Instead of a function, `unite` can also take a binding vector and a body, as seen with the `:operation` transformer.
+The `collect` macro creates a transformation function, by applying a function to the node's children, as seen with the `nil` (root node) transformer above.
+Instead of a function, `collect` can also take a binding vector and a body, as seen with the `:operation` transformer.
 
 ## Writing your own combinator
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Here is an example:
 (-> (parse ... text)
     (transform text
       {:number    (coerce parse-long)
-       :operand   (coerce {\"+\" + \"-\" - \"*\" * \"/\" /})
+       :operand   (coerce {"+" + "-" - "*" * "/" /})
        :operation (unite [[v1 op v2]] (op v1 v2))
        nil        (unite identity)}))
 ```

--- a/README.md
+++ b/README.md
@@ -444,10 +444,10 @@ The `results` namespace contains mostly basic functions for dealing with the par
 These include functions as `success->text` to get the matched text of a node, and `success->children` to get its children.
 While not necessary (as the results tree is made of plain vectors), it does increase readability.
 
-Writing your own parse tree processor is easy.
+Writing your own parse tree processor is easy, as again, it's just data.
 That said, the `results` namespace has a `transform` function.
-This performs a postwalk, transforming the nodes based on their name.
-Two accompanying macros are available, called `coerce` and `unite`.
+This performs a postwalk, transforming the nodes based on their name, using a function that receives the node and the full text.
+Two accompanying helper macros are available, called `coerce` and `unite`.
 Here is an example:
 
 ```clj
@@ -464,7 +464,8 @@ Otherwise it applies the transformation functions, which are functions that rece
 
 The `coerce` macro creates such a transformer, by applying a function to the node's matched text.
 Instead of a function, `coerce` can also take a binding vector and a body.
-So the `:number` transformation above could also be written as `(coerce [s] (parse-long s))`. It could also be written without the macro as `(fn [text node] (parse-long (success->text node text)))`.
+So the `:number` transformation above could be written as `(coerce [s] (parse-long s))`.
+It could also be written without the macro as `(fn [node text] (parse-long (success->text node text)))`.
 
 The `unite` macro creates a transformation function, by applying a function to the node's children, as seen with the `nil` (root node) transformer above.
 Instead of a function, `unite` can also take a binding vector and a body, as seen with the `:operation` transformer.

--- a/README.md
+++ b/README.md
@@ -456,18 +456,18 @@ Here is an example:
       {:number    (coerce parse-long)
        :operand   (coerce {"+" + "-" - "*" * "/" /})
        :operation (unite [[v1 op v2]] (op v1 v2))
-       nil        (unite identity)}))
+       nil        (unite first)}))
 ```
 
 If the parse result is not a success, the `transform` returns it as is.
 Otherwise it applies the transformation functions, which are functions that receives the full text and a node.
 
 The `coerce` macro creates such a transformer, by applying a function to the node's matched text.
-Instead of a function, `coerce` can take a binding vector and a body.
+Instead of a function, `coerce` can also take a binding vector and a body.
 So the `:number` transformation above could also be written as `(coerce [s] (parse-long s))`. It could also be written without the macro as `(fn [text node] (parse-long (success->text node text)))`.
 
 The `unite` macro creates a transformation function, by applying a function to the node's children, as seen with the `nil` (root node) transformer above.
-Instead of a function, `unite` can take a binding vector and a body, as seen with the `:operation` transformer.
+Instead of a function, `unite` can also take a binding vector and a body, as seen with the `:operation` transformer.
 
 ## Writing your own combinator
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ The `results` namespace contains mostly basic functions for dealing with the par
 These include functions as `success->text` to get the matched text of a node, and `success->children` to get its children.
 While not necessary (as the results tree is made of plain vectors), it does increase readability.
 
-Writing your own parse tree processor is easy, it's just vectors.
+Writing your own parse tree processor is easy.
 That said, the `results` namespace has a `transform` function.
 This performs a postwalk, transforming the nodes based on their name.
 Two accompanying macros are available, called `coerce` and `unite`.
@@ -464,9 +464,9 @@ Otherwise it applies the transformation functions, which are functions that rece
 
 The `coerce` macro creates such a transformer, by applying a function to the node's matched text.
 Instead of a function, `coerce` can take a binding vector and a body.
-So the `:number` transformation could also be written as `(coerce [s] (parse-long s))`
+So the `:number` transformation above could also be written as `(coerce [s] (parse-long s))`
 
-The `unite` macro creates a transformation function, by applying a function to the node's children, as seen with the `nil` (root node) transformer.
+The `unite` macro creates a transformation function, by applying a function to the node's children, as seen with the `nil` (root node) transformer above.
 Instead of a function, `unite` can take a binding vector and a body, as seen with the `:operation` transformer.
 
 ## Writing your own combinator

--- a/examples/string-grammar.clj
+++ b/examples/string-grammar.clj
@@ -2,7 +2,7 @@
 
  non-terminal=    #"[a-zA-Z_-]+"
  literal          ("'" > (:literal #"(\\'|[^'])*") "'")
- character-class= ("[" > #"(\\]|[^]])*" "]")
+ character-class= ("[" > #"(\\]|[^]])*" "]" #"[?*+]?")
  regex=           ("#" > literal)
  end-of-file=     "$"
  ref              (non-terminal !"=" space !"<-")

--- a/src/crustimoney/combinators.clj
+++ b/src/crustimoney/combinators.clj
@@ -162,7 +162,7 @@
 
     ([text index result _state]
      (if (r/success? result)
-       #{(r/->error :unexpected-match index {:text (r/success->text text result)})}
+       #{(r/->error :unexpected-match index {:text (r/success->text result text)})}
        (r/->success index index)))))
 
 ;;; Extra combinators

--- a/src/crustimoney/quick.clj
+++ b/src/crustimoney/quick.clj
@@ -8,9 +8,9 @@
             [crustimoney.results :as r]
             [crustimoney.string-grammar :as string-grammar]))
 
-(defn- success->texts [text success]
+(defn- success->texts [success text]
   ((fn inner [success]
-     (into [(r/success->name success) (r/success->text text success)]
+     (into [(r/success->name success) (r/success->text success text)]
            (map inner (r/success->children success))))
    success))
 
@@ -37,4 +37,4 @@
                                   (data-grammar/create-parser definition))})
         result (core/parse (:root rules) text)]
     (when (r/success? result)
-      (success->texts text result))))
+      (success->texts result text))))

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -156,14 +156,14 @@
   "If `result` is a success, it applies the map of `transformations`
   functions in postwalk order based on the node's name. A
   transformation function receives the node and the full `text`. See
-  also `coerce` and `unite` for helpers, for example:
+  also `coerce` and `collect` for helpers, for example:
 
       (-> (parse ... text)
           (transform text
             {:number    (coerce parse-long)
              :operand   (coerce {\"+\" + \"-\" - \"*\" * \"/\" /})
-             :operation (unite [[v1 op v2]] (op v1 v2))
-             nil        (unite first)}))
+             :operation (collect [[v1 op v2]] (op v1 v2))
+             nil        (collect first)}))
 
   If `result` is not a success, it is returned as is."
   [result text transformations]
@@ -191,14 +191,14 @@
       (let [~(first binding) (success->text success# text#)]
         ~@body))))
 
-(defmacro unite
+(defmacro collect
   "Evaluates to a transformation function. It applies function `f` to
   the children of the success node, or takes a `binding` vector, where
   the children are bound to, for use in the `body`. For example:
 
-      (unite first)
+      (collect first)
 
-      (unite [[val1 op val2]] (op val1 val2))"
+      (collect [[val1 op val2]] (op val1 val2))"
   {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [success# _#]

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -151,7 +151,7 @@
             {:number    (coerce parse-long)
              :operand   (coerce {\"+\" + \"-\" - \"*\" * \"/\" /})
              :operation (unite [[v1 op v2]] (op v1 v2))
-             nil        (unite identity)}
+             nil        (unite identity)}))
 
   If `result` is not a success, it is returned as is."
   [result text transformations]

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -174,14 +174,16 @@
         success))))
 
 (defmacro coerce
-  "Evaluates to a transformation function. It applies function `f` to
-  the matched text of the success node, or takes a `binding` vector,
-  where the matched text is bound to, available for use in the `body`.
-  For example:
+  "Evaluates to function that takes a success node and the full parsed
+  text. It applies function `f` to the matched text of the success
+  node, or it binds the matched text to the `binding` vector and
+  executes `body`. For example:
 
       (coerce parse-long)
 
-      (coerce [s] (-> s upper-case reverse str))"
+      (coerce [s] (-> s upper-case reverse str))
+
+  Can be used with `transform`."
   {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [success# text#]
@@ -192,13 +194,16 @@
         ~@body))))
 
 (defmacro collect
-  "Evaluates to a transformation function. It applies function `f` to
-  the children of the success node, or takes a `binding` vector, where
-  the children are bound to, for use in the `body`. For example:
+  "Evaluates to function that takes a success node and the full parsed
+  text. It applies function `f` to the children of the success node,
+  or it binds the children to the `binding` vector and executes
+  `body`. For example:
 
       (collect first)
 
-      (collect [[val1 op val2]] (op val1 val2))"
+      (collect [[val1 op val2]] (op val1 val2))
+
+  Can be used with `transform`."
   {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [success# _#]

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -143,10 +143,7 @@
 
 ;;; Transformation helpers
 
-(defn postwalk
-  "If `result` is a success, function `f` is called on each tree node,
-  in postwalk order."
-  [result f]
+(defn- postwalk [result f]
   (let [inner (fn inner [success]
                 (let [children (map inner (success->children success))]
                   (f (with-success-children success children))))]

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -171,16 +171,13 @@
         success))))
 
 (defmacro coerce
-  "Evaluates to function that takes a success node and the full parsed
-  text. It applies function `f` to the matched text of the success
-  node, or it binds the matched text to the `binding` vector and
-  executes `body`. For example:
+  "Transformer for use with `transform`. It applies function `f` to the
+  matched text of the success node, or it binds the matched text to
+  the `binding` vector and executes `body`. For example:
 
       (coerce parse-long)
 
-      (coerce [s] (-> s upper-case reverse str))
-
-  Can be used with `transform`."
+      (coerce [s] (-> s upper-case reverse str))"
   {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [success# text#]
@@ -191,16 +188,13 @@
         ~@body))))
 
 (defmacro collect
-  "Evaluates to function that takes a success node and the full parsed
-  text. It applies function `f` to the children of the success node,
-  or it binds the children to the `binding` vector and executes
-  `body`. For example:
+  "Transformer for use with `transform`. It applies function `f` to the
+  children of the success node, or it binds the children to the
+  `binding` vector and executes `body`. For example:
 
       (collect first)
 
-      (collect [[val1 op val2]] (op val1 val2))
-
-  Can be used with `transform`."
+      (collect [[val1 op val2]] (op val1 val2))"
   {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [success# _#]

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -174,6 +174,7 @@
       (coerce parse-long)
 
       (coerce [s] (-> s upper-case reverse str))"
+  {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [text# success#]
       (~f (success->text success# text#))))
@@ -191,6 +192,7 @@
       (unite +)
 
       (unite [[val1 op val2]] (op val1 val2))"
+  {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [_# success#]
       (apply ~f (success->children success#))))

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -155,7 +155,7 @@
 (defn transform
   "If `result` is a success, it applies the map of `transformations`
   functions in postwalk order based on the node's name. A
-  transformation function receives the full `text` and the node. See
+  transformation function receives the node and the full `text`. See
   also `coerce` and `unite` for helpers, for example:
 
       (-> (parse ... text)

--- a/src/crustimoney/results.clj
+++ b/src/crustimoney/results.clj
@@ -154,7 +154,7 @@
             {:number    (coerce parse-long)
              :operand   (coerce {\"+\" + \"-\" - \"*\" * \"/\" /})
              :operation (unite [[v1 op v2]] (op v1 v2))
-             nil        (unite identity)}))
+             nil        (unite first)}))
 
   If `result` is not a success, it is returned as is."
   [result text transformations]
@@ -166,10 +166,10 @@
     (cond-> result (success? result) inner)))
 
 (defmacro coerce
-  "Creates a transformation function. It applies function `f` to the
-  matched text of the success node, or takes a `binding` vector, where
-  the matched text is bound to, available for use in the `body`. For
-  example:
+  "Evaluates to a transformation function. It applies function `f` to
+  the matched text of the success node, or takes a `binding` vector,
+  where the matched text is bound to, available for use in the `body`.
+  For example:
 
       (coerce parse-long)
 
@@ -184,18 +184,17 @@
         ~@body))))
 
 (defmacro unite
-  "Creates a transformation function. It applies function `f` to the
-  children of the success node, or takes a `binding` vector, where
-  each of the children are bound to, for use in the `body`. For
-  example:
+  "Evaluates to a transformation function. It applies function `f` to
+  the children of the success node, or takes a `binding` vector, where
+  the children are bound to, for use in the `body`. For example:
 
-      (unite +)
+      (unite first)
 
       (unite [[val1 op val2]] (op val1 val2))"
   {:clj-kondo/lint-as 'clojure.core/fn}
   ([f]
    `(fn [_# success#]
-      (apply ~f (success->children success#))))
+      (~f (success->children success#))))
   ([binding & body]
    `(fn [_# success#]
       (let [~(first binding) (success->children success#)]

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -102,11 +102,11 @@
    :choice (r/unite [children] (into [:choice] children))
 
    :rule-name (r/coerce keyword)
-   :rule      (r/unite vector)
+   :rule      (r/unite vec)
    :rules     (r/unite [rules] (into {} rules))
 
-   :no-rules (r/unite identity)
-   :root     (r/unite identity)})
+   :no-rules (r/unite first)
+   :root     (r/unite first)})
 
 (defn ^:no-doc vector-tree-for [success text]
   (r/transform success text transformations))

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -185,7 +185,7 @@
 
    :operand (r/coerce {"!" :negate "&" :lookahead "?" :maybe "+" :repeat+ "*" :repeat*})
 
-   :end-of-file (r/coerce [s] [:eof])
+   :end-of-file (r/coerce [_] [:eof])
 
    :cut (r/coerce {">>" :hard-cut, ">" :soft-cut})})
 

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -86,27 +86,27 @@
   {:non-terminal    (r/coerce [s] [:ref (keyword s)])
    :literal         (r/coerce [s] [:literal (unescape-quotes s)])
    :character-class (r/coerce [s] [:regex s])
-   :regex           (r/unite [[literal]] [:regex (second literal)])
+   :regex           (r/collect [[literal]] [:regex (second literal)])
    :end-of-file     (r/coerce [_] [:eof])
 
    :group-name (r/coerce keyword)
-   :group      (r/unite [[child1 child2]] (if child2 [:with-name child1 child2] child1))
+   :group      (r/collect [[child1 child2]] (if child2 [:with-name child1 child2] child1))
 
    :operand    (r/coerce {"!" :negate "&" :lookahead "?" :maybe "+" :repeat+ "*" :repeat*})
-   :quantified (r/unite [[expr operand]] [operand expr])
-   :lookahead  (r/unite [[operand expr]] [operand expr])
+   :quantified (r/collect [[expr operand]] [operand expr])
+   :lookahead  (r/collect [[operand expr]] [operand expr])
 
    :cut (r/coerce {">>" :hard-cut, ">" :soft-cut})
 
-   :chain  (r/unite [children] (into [:chain] children))
-   :choice (r/unite [children] (into [:choice] children))
+   :chain  (r/collect [children] (into [:chain] children))
+   :choice (r/collect [children] (into [:choice] children))
 
    :rule-name (r/coerce keyword)
-   :rule      (r/unite vec)
-   :rules     (r/unite [rules] (into {} rules))
+   :rule      (r/collect vec)
+   :rules     (r/collect [rules] (into {} rules))
 
-   :no-rules (r/unite first)
-   :root     (r/unite first)})
+   :no-rules (r/collect first)
+   :root     (r/collect first)})
 
 (defn ^:no-doc vector-tree-for [success text]
   (r/transform success text transformations))

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -58,7 +58,7 @@
 
      non-terminal=    #"[a-zA-Z_-]+"
      literal          ("'" > (:literal #"(\\'|[^'])*") "'")
-     character-class= ("[" > #"(\\]|[^]])*" "]")
+     character-class= ("[" > #"(\\]|[^]])*" "]" #"[?*+]?")
      regex=           ("#" > literal)
      end-of-file=     "$"
 

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -189,7 +189,7 @@
 
    :cut (r/coerce {">>" :hard-cut, ">" :soft-cut})})
 
-(defn ^:no-doc vector-tree-for [text success]
+(defn ^:no-doc vector-tree-for [success text]
   (r/transform success text transformations))
 
 ;;; Public namespace API
@@ -200,10 +200,11 @@
   `crustimoney.vector-grammar` for more on this format. This can be
   useful for debugging."
   [text]
-  (let [result (core/parse (:root grammar) text)]
+  (let [result (-> (core/parse (:root grammar) text)
+                   (r/errors->line-column text))]
     (if (set? result)
-      (throw (ex-info "Failed to parse grammar" {:errors (r/errors->line-column text result)}))
-      (vector-tree-for text result))))
+      (throw (ex-info "Failed to parse grammar" {:errors result}))
+      (vector-tree-for result text))))
 
 (defn create-parser
   "Create a parser based on a string-based grammar definition. If the

--- a/test/crustimoney/results_test.clj
+++ b/test/crustimoney/results_test.clj
@@ -1,6 +1,6 @@
 (ns crustimoney.results-test
   (:require [clojure.set :as set]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [deftest testing is]]
             [crustimoney.results :as r]))
 
 (deftest errors->line-column-test
@@ -12,3 +12,25 @@
                    {:at 5 :line 3 :column 1}
                    {:at 8 :line 3 :column 4}}]
     (is (= expected (r/errors->line-column (set/project expected [:at]) text)))))
+
+(deftest transform-test
+  (testing "not a success"
+    (is (= :foo (r/transform :foo "" nil))))
+
+  (testing "no transformer"
+    (let [node [:foo {:start 0, :end 3}]]
+      (is (= node (r/transform node "" nil)))))
+
+  (testing "only children have transformer"
+    (let [node [:foo {:start 0, :end 3}
+                [:bar {:start 0, :end 3}]]]
+      (is (= [:foo {:start 0, :end 3} "child"]
+             (r/transform node "bar" {:bar (constantly "child")})))))
+
+  (testing "postwalk order"
+    (let [node [:plus {:start 0, :end 2}
+                [:number {:start 0, :end 2}]
+                [:number {:start 3, :end 5}]]]
+      (is (= 42 (r/transform node "20 22"
+                  {:plus   (r/unite +)
+                   :number (r/coerce parse-long)}))))))

--- a/test/crustimoney/results_test.clj
+++ b/test/crustimoney/results_test.clj
@@ -32,5 +32,5 @@
                 [:number {:start 0, :end 2}]
                 [:number {:start 3, :end 5}]]]
       (is (= 42 (r/transform node "20 22"
-                  {:plus   (r/unite +)
+                  {:plus   (r/unite [ns] (reduce + ns))
                    :number (r/coerce parse-long)}))))))

--- a/test/crustimoney/results_test.clj
+++ b/test/crustimoney/results_test.clj
@@ -32,5 +32,5 @@
                 [:number {:start 0, :end 2}]
                 [:number {:start 3, :end 5}]]]
       (is (= 42 (r/transform node "20 22"
-                  {:plus   (r/unite [ns] (reduce + ns))
+                  {:plus   (r/collect [ns] (reduce + ns))
                    :number (r/coerce parse-long)}))))))

--- a/test/crustimoney/results_test.clj
+++ b/test/crustimoney/results_test.clj
@@ -11,4 +11,4 @@
                    {:at 4 :line 2 :column 1}
                    {:at 5 :line 3 :column 1}
                    {:at 8 :line 3 :column 4}}]
-    (is (= expected (r/errors->line-column text (set/project expected [:at]))))))
+    (is (= expected (r/errors->line-column (set/project expected [:at]) text)))))

--- a/test/examples_test.clj
+++ b/test/examples_test.clj
@@ -79,7 +79,7 @@
     (testing "string grammar"
       (let [parser (from-peg "string-grammar.peg")
             result (core/parse (:root parser) input)
-            vtree  (string-grammar/vector-tree-for input result)
+            vtree  (string-grammar/vector-tree-for result input)
             parser (vector-grammar/create-parser vtree)
             result (core/parse (:root parser) input)]
         (is (r/success? result))))
@@ -87,7 +87,7 @@
     (testing "data grammar"
       (let [parser (from-clj "string-grammar.clj")
             result (core/parse (:root parser) input)
-            vtree  (string-grammar/vector-tree-for input result)
+            vtree  (string-grammar/vector-tree-for result input)
             parser (vector-grammar/create-parser vtree)
             result (core/parse (:root parser) input)]
         (is (r/success? result))))))


### PR DESCRIPTION
The string-grammar internals have been updated to use this, as a test case.