### PR TITLE
Grammar combinator now returns a parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The instructions for the latest version can be found here: [![Clojars Project](h
 
 While the library is suitable for complex grammars, you may only want a simple parser where a regular expression just doesn't cut it.
 For this there is the `crustimoney.quick/parse` function.
-It takes a string- or data-driven parser definition and a string, creates a parser internally, tries to parse the string, and returns the result if it matched.
+It takes a string- or data-driven parser definition and a text, creates a parser on the fly internally, tries to parse the text, and returns the result if it matched.
+The result is processed such that the matched strings are directly in the tree.
 For example:
 
 ```clj
@@ -154,12 +155,13 @@ For example:
     :bax  (regex "ba(r|z)")}))
 ```
 
-This will return a normal map, where the refs have been bound to the rules in the grammar.
+This will return a parser, where the refs have been bound to the rules in the grammar.
 The macro will ensure that all references resolve correctly.
+It expects at least a `:root` entry, which is the starting rule.
 This grammar can be used as follows:
 
 ```clj
-(core/parse (:root my-grammar) "foobaz")
+(core/parse my-grammar "foobaz")
 => [nil {:start 0, :end 6}]
 ```
 
@@ -168,7 +170,7 @@ The macro can also be nested, where it is the most outer one that does the actua
 
 ## Auto-named rules
 
-The example above shows that all success nodes are filtered out, except the root node, as they are nameless.
+The example above shows that all success nodes are filtered out, since they are nameless.
 The parsers could be wrapped with `with-name`, but the names would probably be the same as the rule names in this case.
 Appending an `=` to the rule name will automatically wrap the parser with `with-name`.
 This would update the grammar to:

--- a/examples/calc.clj
+++ b/examples/calc.clj
@@ -1,4 +1,6 @@
-{sum ((:sum product sum-op > sum) / product)
+{root sum
+
+ sum ((:sum product sum-op > sum) / product)
 
  product ((:product value product-op > product) / value)
 

--- a/examples/calc.edn
+++ b/examples/calc.edn
@@ -1,4 +1,6 @@
-{sum ((:sum product sum-op > sum) / product)
+{root sum
+
+ sum ((:sum product sum-op > sum) / product)
 
  product ((:product value product-op > product) / value)
 

--- a/examples/calc.peg
+++ b/examples/calc.peg
@@ -1,3 +1,5 @@
+root       <- sum
+
 sum        <- (:sum product sum-op > sum) / product
 
 product    <- (:product value product-op > product) / value

--- a/src/crustimoney/combinators.clj
+++ b/src/crustimoney/combinators.clj
@@ -277,7 +277,7 @@
       (let [result (swap! *parsers* merge (auto-capture (f)))]
         (if-let [unknown-refs (seq (remove result (keys result)))]
           (throw (ex-info "Detected unknown keys in refs" {:unknown-keys unknown-refs}))
-          result)))))
+          (or (:root result) (throw (IllegalArgumentException. "Missing :root entry in grammar"))))))))
 
 (defmacro grammar
   "Takes one or more maps, in which the entries can refer to each other

--- a/src/crustimoney/data_grammar.clj
+++ b/src/crustimoney/data_grammar.clj
@@ -152,11 +152,8 @@
 ;;; Parser creation
 
 (defn create-parser
-  "Create a parser based on a datagrammar definition. If a map with
-  rules is supplied, a map of parsers is returned. Otherwise a single
-  parser is returned.
-
-  See namespace documentation for the data-grammar format."
+  "Create a parser based on a datagrammar definition. See namespace
+  documentation for the data-grammar format."
   [data]
   (-> (vector-tree data)
       (vector-grammar/create-parser)))

--- a/src/crustimoney/quick.clj
+++ b/src/crustimoney/quick.clj
@@ -31,10 +31,10 @@
 
   When the result is an error, nil is returned."
   [definition text]
-  (let [rules (c/grammar built-ins/all
-                         {:root (if (string? definition)
-                                  (string-grammar/create-parser definition)
-                                  (data-grammar/create-parser definition))})
-        result (core/parse (:root rules) text)]
+  (let [parser (c/grammar built-ins/all
+                          {:root (if (string? definition)
+                                   (string-grammar/create-parser definition)
+                                   (data-grammar/create-parser definition))})
+        result (core/parse parser text)]
     (when (r/success? result)
       (success->texts result text))))

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -126,10 +126,8 @@
       (vector-tree-for result text))))
 
 (defn create-parser
-  "Create a parser based on a string-based grammar definition. If the
-  definition contains multiple rules, a map of parsers is returned.
-
-  See the namespace documentation for the string format."
+  "Create a parser based on a string-based grammar definition. See the
+  namespace documentation for the string format."
   [text]
   (-> (vector-tree text)
       (vector-grammar/create-parser)))

--- a/src/crustimoney/string_grammar.clj
+++ b/src/crustimoney/string_grammar.clj
@@ -119,7 +119,7 @@
   `crustimoney.vector-grammar` for more on this format. This can be
   useful for debugging."
   [text]
-  (let [result (-> (core/parse (:root grammar) text)
+  (let [result (-> (core/parse grammar text)
                    (r/errors->line-column text))]
     (if (set? result)
       (throw (ex-info "Failed to parse grammar" {:errors result}))

--- a/src/crustimoney/vector_grammar.clj
+++ b/src/crustimoney/vector_grammar.clj
@@ -31,9 +31,9 @@
 
   Each vector is expanded into the combinator invocation, referenced
   by the first keyword. If the keyword does not have a namespace,
-  `crustimoney.combinators` is assumed. Maps are walked as well,
-  wrapped in `crustimoney.combinators/grammar`. Other data is left
-  as-is."
+  `crustimoney.combinators` is assumed. The outer map is walked as
+  well, wrapped in `crustimoney.combinators/grammar`. Other data is
+  left as-is."
   [tree]
   (if (map? tree)
     (c/grammar (update-vals tree create-parser*))

--- a/test/crustimoney/combinators_test.clj
+++ b/test/crustimoney/combinators_test.clj
@@ -168,15 +168,30 @@
   (testing "simple grammar"
     (let [p (c/grammar {:root (c/ref :foo)
                         :foo  (c/literal "foo")})]
-      (is (= (r/->success 0 3) (parse (:root p) "foo")))))
+      (is (= (r/->success 0 3) (parse p "foo")))))
 
   (testing "auto-capture rules"
     (let [p (c/grammar {:root (c/ref :foo)
                         :foo= (c/literal "foo")})]
       (is (= (r/with-success-name :foo (r/->success 0 3))
-             (parse (:root p) "foo")))))
+             (parse p "foo")))))
 
   (testing "missing references"
     (let [thrown (try (c/grammar {:root (c/ref :foo)}) (catch Exception e e))]
       (is (= "Detected unknown keys in refs" (.getMessage thrown)))
-      (is (= {:unknown-keys [:foo]} (ex-data thrown))))))
+      (is (= {:unknown-keys [:foo]} (ex-data thrown)))))
+
+  (testing "missing :root entry"
+    (let [thrown (try (c/grammar {:not-root (c/literal "whut")}) (catch Exception e e))]
+      (is (= "Missing :root entry in grammar" (.getMessage thrown)))))
+
+  (testing "set root"
+    (let [p (c/grammar {:foo (c/literal "foo")}
+                       {:root (c/ref :foo)})]
+      (is (r/success? (parse p "foo")))))
+
+  (testing "override root"
+    (let [p (c/grammar {:root (c/literal "foo")
+                        :bar  (c/literal "bar")}
+                       {:root (c/ref :bar)})]
+      (is (r/success? (parse p "bar"))))))

--- a/test/crustimoney/core_test.clj
+++ b/test/crustimoney/core_test.clj
@@ -23,20 +23,20 @@
              (core/parse p "foobar" {:keep-nameless? true})))))
 
   (testing "resiliency against infinite loops"
-    (let [grammar (c/grammar {:a (c/ref :b), :b (c/ref :c), :c (c/ref :a)})]
+    (let [grammar (c/grammar {:root (c/ref :b), :b (c/ref :c), :c (c/ref :root)})]
       (is (thrown-with-msg? Exception #"Infinite parsing loop detected"
-                            (core/parse (:a grammar) "anything"))))
+                            (core/parse grammar "anything"))))
 
-    (let [grammar (c/grammar {:a (c/chain (c/choice (c/maybe (c/repeat* (c/ref :b)))))
-                              :b (c/ref :a)})]
+    (let [grammar (c/grammar {:root (c/chain (c/choice (c/maybe (c/repeat* (c/ref :b)))))
+                              :b    (c/ref :root)})]
       (is (thrown-with-msg? Exception #"Infinite parsing loop detected"
-                            (core/parse (:a grammar) "anything")))))
+                            (core/parse grammar "anything")))))
 
   (testing "resiliency against stack overflow"
-    (let [grammar   (c/grammar {:a (c/choice (c/chain (c/literal "a") (c/ref :a))
-                                             (c/literal "a"))})
+    (let [grammar   (c/grammar {:root (c/choice (c/chain (c/literal "a") (c/ref :root))
+                                                (c/literal "a"))})
           long-text (apply str (repeat 10000 "a"))]
-      (is (r/success? (core/parse (:a grammar) long-text)))))
+      (is (r/success? (core/parse grammar long-text)))))
 
   (testing "report unknown parser function result"
     (let [thrown (try (core/parse (constantly :whut) "anything") (catch Exception e e))]

--- a/test/crustimoney/data_grammar_test.clj
+++ b/test/crustimoney/data_grammar_test.clj
@@ -52,13 +52,13 @@
              (core/parse p "foobarfoobar")))))
 
   (testing "recursive grammars"
-    (let [p (create-parser '{expr (foo bar), foo "foo", bar "bar"})]
-      (is (r/success? (core/parse (:expr p) "foobar")))))
+    (let [p (create-parser '{root (foo bar), foo "foo", bar "bar"})]
+      (is (r/success? (core/parse p "foobar")))))
 
   (testing "auto-named rule"
-    (let [p (create-parser '{expr= ("foo" $)})]
-      (is (= (r/with-success-name :expr (r/->success 0 3))
-             (core/parse (:expr p) "foo")))))
+    (let [p (create-parser '{root= ("foo" $)})]
+      (is (= (r/with-success-name :root (r/->success 0 3))
+             (core/parse p "foo")))))
 
   (testing "star quantifier"
     (let [p (create-parser '("foo"*))]
@@ -108,7 +108,7 @@
   (testing "extra rules"
     (let [p (c/grammar (create-parser '{root foo})
                        {:foo (create-parser "foo")})]
-      (is (r/success? (core/parse (:root p) "foo")))))
+      (is (r/success? (core/parse p "foo")))))
 
   (testing "unknown type"
     (is (thrown-with-msg? Exception #"Unknown data type"

--- a/test/crustimoney/string_grammar_test.clj
+++ b/test/crustimoney/string_grammar_test.clj
@@ -70,13 +70,13 @@
              (core/parse p "foobarfoobar")))))
 
   (testing "recursive grammars"
-    (let [p (create-parser "expr <- foo bar, foo <- 'foo'\nbar <- 'bar'")]
-      (is (r/success? (core/parse (:expr p) "foobar")))))
+    (let [p (create-parser "root <- foo bar, foo <- 'foo'\nbar <- 'bar'")]
+      (is (r/success? (core/parse p "foobar")))))
 
   (testing "auto-named rule"
-    (let [p (create-parser "expr= <- 'foo' $")]
-      (is (= (r/with-success-name :expr (r/->success 0 3))
-             (core/parse (:expr p) "foo")))))
+    (let [p (create-parser "root= <- 'foo' $")]
+      (is (= (r/with-success-name :root (r/->success 0 3))
+             (core/parse p "foo")))))
 
   (testing "star quantifier"
     (let [p (create-parser "'foo'*")]
@@ -126,7 +126,7 @@
   (testing "extra rules"
     (let [p (c/grammar (create-parser "root <- foo")
                        {:foo (create-parser "'foo'")})]
-      (is (r/success? (core/parse (:root p) "foo")))))
+      (is (r/success? (core/parse p "foo")))))
 
   (testing "report grammar errors"
     (let [thrown (try (create-parser "(foo") (catch Exception e e))]

--- a/test/crustimoney/vector_grammar_test.clj
+++ b/test/crustimoney/vector_grammar_test.clj
@@ -17,19 +17,19 @@
   (testing "map of vectors with refs"
     (let [p (create-parser {:root [:chain [:literal "foo"] [:ref :bax]]
                             :bax  [:regex "ba(r|z)"]})]
-      (is (= (r/->success 0 6) (core/parse (:root p) "foobaz")))))
+      (is (= (r/->success 0 6) (core/parse p "foobaz")))))
 
   (testing "map of vectors with = postfix keys"
     (let [p (create-parser {:root [:chain [:literal "foo"] [:ref :bax]]
                             :bax= [:regex "ba(r|z)"]})]
       (is (= (r/->success 0 6 [(r/with-success-name :bax (r/->success 3 6))])
-             (core/parse (:root p) "foobaz")))))
+             (core/parse p "foobaz")))))
 
   (testing "arbitrary values"
     (let [p (create-parser {:root [:chain [:literal "foo"] [:with-name :bax [:ref :bax]]]
                             :bax  (c/regex "ba(r|z)")})]
       (is (= (r/->success 0 6 [(r/with-success-name :bax (r/->success 3 6))])
-             (core/parse (:root p) "foobaz")))))
+             (core/parse p "foobaz")))))
 
   (testing "custom combinator"
     #_{:clj-kondo/ignore [:inline-def]}

--- a/test/examples_test.clj
+++ b/test/examples_test.clj
@@ -1,6 +1,7 @@
 (ns examples-test
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest testing is]]
+            [crustimoney.combinators :as c]
             [crustimoney.core :as core]
             [crustimoney.data-grammar :as data-grammar]
             [crustimoney.results :as r]
@@ -44,15 +45,19 @@
 
     (testing "string grammar"
       (let [p (from-peg "calc.peg")]
-        (is (= expected (core/parse (:sum p) input)))))
+        (is (= expected (core/parse p input)))))
 
     (testing "data grammar"
       (let [p (from-clj "calc.clj")]
-        (is (= expected (core/parse (:sum p) input)))))
+        (is (= expected (core/parse p input)))))
 
     (testing "edn grammar"
       (let [p (from-edn "calc.edn")]
-        (is (= expected (core/parse (:sum p) input)))))))
+        (is (= expected (core/parse p input)))))
+
+    (testing "string grammar override root"
+      (let [p (c/grammar (from-peg "calc.peg") {:root (c/ref :number)})]
+        (is (= [:number {:start 0, :end 1}] (core/parse p input)))))))
 
 (deftest json-test
   (let [input    "[{\"bool\": true, \"not bool\":false ,\"int\": -83.4,
@@ -68,26 +73,26 @@
 
     (testing "string grammar"
       (let [p (from-peg "json.peg")]
-        (is (= expected (core/parse (:root p) input)))))
+        (is (= expected (core/parse p input)))))
 
     (testing "data grammar"
       (let [p (from-clj "json.clj")]
-        (is (= expected (core/parse (:root p) input)))))))
+        (is (= expected (core/parse p input)))))))
 
 (deftest string-grammar-test
   (let [input (from "string-grammar.peg")]
     (testing "string grammar"
       (let [parser (from-peg "string-grammar.peg")
-            result (core/parse (:root parser) input)
+            result (core/parse parser input)
             vtree  (string-grammar/vector-tree-for result input)
             parser (vector-grammar/create-parser vtree)
-            result (core/parse (:root parser) input)]
+            result (core/parse parser input)]
         (is (r/success? result))))
 
     (testing "data grammar"
       (let [parser (from-clj "string-grammar.clj")
-            result (core/parse (:root parser) input)
+            result (core/parse parser input)
             vtree  (string-grammar/vector-tree-for result input)
             parser (vector-grammar/create-parser vtree)
-            result (core/parse (:root parser) input)]
+            result (core/parse parser input)]
         (is (r/success? result))))))


### PR DESCRIPTION
Before this change, the grammar macro would return a map. This could lead to the impression that this map could be reused or altered, and the refs would update. But this is a false impression. The refs are bound as soon as the (outer) grammar combinator is done, and cannot be rebound.

This change does lead to forcing a :root rule in the grammar. If a grammar does not have this, it is easily added, since the grammar combinator takes multiple maps. The same strategy can be used when testing individual rules (i.e. starting the parse from a different rule than root).